### PR TITLE
Use Psych module for YAML parsing

### DIFF
--- a/bin/beanstalk-import.rb
+++ b/bin/beanstalk-import.rb
@@ -8,7 +8,7 @@ filename = $*.shift
 BS=Beanstalk::Connection.new $*.first
 
 f=open filename do |f|
-  YAML.each_document(f) do |y|
+  Psych.load_stream(f) do |y|
     BS.use y[:tube]
     body, pri, t, ttr = [:body, :pri, :when, :ttr].map{|a| y[a]}
 


### PR DESCRIPTION
Upgrade the YAML parsing module to run in ruby versions > 2.1.0.